### PR TITLE
Use `yarn` over `npm` in root docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN dotnet restore Server/Nikeza.Server/Nikeza.Server.fsproj
     
 
 COPY Client/app/*.json Client/app/
-RUN cd Client/app \
+RUN npm install -g yarn \
+    && cd Client/app \
     && npm install -g elm \
-    && npm install \
+    && yarn install \
     && elm-package install -y
 
 COPY . .


### PR DESCRIPTION
We want to use yarn since NPM <= v4.x does not guarantee the same node_module versions between clean installs. yarn uses a lock file to make sure the same package is used each time.

We should probably use the `node_modules` elm binaries like we do in the [Client/app/package.json](https://github.com/Lambda-Cartel/Nikeza/blob/master/Client/app/package.json#L7) this pins the elm version. I'll look at making another PR for that latter.