### PR TITLE
Added IIS Integration Support

### DIFF
--- a/Server/Nikeza.Server/Nikeza.Server.fsproj
+++ b/Server/Nikeza.Server/Nikeza.Server.fsproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.*"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.*" />

--- a/Server/Nikeza.Server/Program.fs
+++ b/Server/Nikeza.Server/Program.fs
@@ -14,6 +14,7 @@ let main argv =
     WebHostBuilder()
         .UseKestrel()
         .UseContentRoot(Directory.GetCurrentDirectory())
+        .UseIISIntegration()
         .Configure(Action<IApplicationBuilder> configureApp)
         .ConfigureServices(Action<IServiceCollection> configureServices)
         .ConfigureLogging(Action<ILoggerFactory> configureLogging)


### PR DESCRIPTION
Fixes the Annoying Bug that prevented us from deploying the App to Azure.

IIS Integration Support is included by default in ASP.NET Mvc Template but was excluded in Giraffe

That said the real application is now live here https://nikeza.azurewebsites.net/